### PR TITLE
作成したsystemdサービスのファイル名に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ WantedBy=multi-user.target
 
 ```
 sudo systemctl daemon-reload
-sudo systemctl enable media-proxy
-sudo systemctl start media-proxy
+sudo systemctl enable misskey-proxy
+sudo systemctl start misskey-proxy
 ```
 
 3000ポートまでnginxなどでルーティングしてやります。


### PR DESCRIPTION
# Why
上で作成したsystemdサービスのファイル名と,その後の有効化と起動のサービス名が違っていて起動できていなかった

# What
作成したサービス名に統一する