### PR TITLE
fix: turn http2 OFF

### DIFF
--- a/built/download.js
+++ b/built/download.js
@@ -38,7 +38,7 @@ export async function downloadUrl(url, path, settings = defaultDownloadConfig) {
             http: settings.httpAgent,
             https: settings.httpsAgent,
         },
-        http2: true,
+        http2: false, // default
         retry: {
             limit: 0,
         },

--- a/src/download.ts
+++ b/src/download.ts
@@ -57,7 +57,7 @@ export async function downloadUrl(url: string, path: string, settings:DownloadCo
             http: settings.httpAgent,
             https: settings.httpsAgent,
         },
-        http2: true,
+        http2: false,	// default
         retry: {
             limit: 0,
         },


### PR DESCRIPTION
forward proxy is not available if http2 is ON
And Misskey original proxy is not using http2.

fix: https://github.com/misskey-dev/media-proxy/issues/10